### PR TITLE
Remove Error if tooltip is disabled

### DIFF
--- a/draggable-points.js
+++ b/draggable-points.js
@@ -87,7 +87,9 @@
                 function () {
                     proceed = true;
                     dragPoint.update([newX, newY], false);
-                    chart.tooltip.refresh(chart.tooltip.shared ? [dragPoint] : dragPoint);
+                    if (chart.tooltip) {
+                        chart.tooltip.refresh(chart.tooltip.shared ? [dragPoint] : dragPoint);
+                    }
                     if (series.stackKey) {
                         chart.redraw();
                     } else {


### PR DESCRIPTION
If tooltip is disabled, this throws an error:

Uncaught TypeError: Cannot read property 'shared' of undefined
