### PR TITLE
Dragging after mouse has left chart area

### DIFF
--- a/draggable-points.js
+++ b/draggable-points.js
@@ -217,13 +217,12 @@
         chart.redraw();
 
         // Add'em
-        addEvent(container, 'mousemove', mouseMove);
-        addEvent(container, 'touchmove', mouseMove);
+        addEvent(document, 'mousemove', mouseMove);
+        addEvent(document, 'touchmove', mouseMove);
         addEvent(container, 'mousedown', mouseDown);
         addEvent(container, 'touchstart', mouseDown);
         addEvent(document, 'mouseup', drop);
         addEvent(document, 'touchend', drop);
-        addEvent(container, 'mouseleave', drop);
     });
 
     /**


### PR DESCRIPTION
This allows the user to keep dragging after the mouse has left the chart area. This makes dragging column charts more smooth.