### PR TITLE
added option to continue dragging when mouse leaves chart area

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Online demos:
 | `plotOptions.series.data.draggableY` | Boolean | If dragging is enabled on the series, set this to false to prevent dragging on a single point. |
 | `plotOptions.series.draggableX` | Boolean | Enable draggable along the X axis. |
 | `plotOptions.series.draggableY` | Boolean | Enable draggable along the Y axis. |
+| `plotOptions.series.allowDragOutsideChartArea` | Boolean | Dragging will contine outside chart area. Defaults to false which automatically triggers a drop on mouseleave. |
 | `plotOptions.series.dragHandlePath` | Function | Column series only. A custom path for the drag handle. |
 | `plotOptions.series.dragHandleFill` | Function | Column series only. Fill color for the drag handle. |
 | `plotOptions.series.dragHandleStroke` | Function | Column series only. Stroke color for the drag handle. |

--- a/draggable-points.js
+++ b/draggable-points.js
@@ -2,7 +2,7 @@
  * Draggable points plugin for Highcharts JS
  * Author: Torstein Honsi
  * License: MIT License
- * Version: 2.0.4 (2016-05-23)
+ * Version: 2.0.6 (2017-02-03)
  */
 
 /*global document, Highcharts */
@@ -232,6 +232,12 @@
             }
         }
 
+        function conditionalDrop(e) {
+            if (dragPoint && dragPoint.series.options.allowDragOutsideChartArea) {
+                return;
+            }
+            drop(e);
+        }
         // Kill animation on first drag when chart.animation is set to false.
         chart.redraw();
 
@@ -242,7 +248,7 @@
         addEvent(container, 'touchstart', mouseDown);
         addEvent(document, 'mouseup', drop);
         addEvent(document, 'touchend', drop);
-        addEvent(container, 'mouseleave', drop);
+        addEvent(container, 'mouseleave', conditionalDrop)
     });
 
     /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Draggable Points",
-    "version": "2.0.4",
+    "version": "2.0.6",
     "title": "Highcharts Draggable Points",
     "demo": [
         "[Combined series](http://jsfiddle.net/highcharts/AyUbx/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-draggable-points",
-  "version": "2.0.4",
+  "version": "2.0.6",
   "description": "Highcharts plugin that allows points to be dragged and dropped by mouse or touch.",
   "main": "draggable-points.js",
   "repository": {


### PR DESCRIPTION
**why:** when dragging to the very edge and the mouse leaves chart area the point sticks and you have to release the click and grab the point again. UX-wise looks not nice.