### PR TITLE
handling not defined useDragHandle()

### DIFF
--- a/draggable-points.js
+++ b/draggable-points.js
@@ -308,7 +308,7 @@
         proceed.apply(series);
 
         if (
-            this.useDragHandle() &&
+            this.useDragHandle && this.useDragHandle() &&
             (options.draggableX || options.draggableY)
         ) {
 


### PR DESCRIPTION
if useDragHandle() is not defined, code path doesn't fail